### PR TITLE
Fix thumbnails on videos

### DIFF
--- a/lib/utils/compressor.dart
+++ b/lib/utils/compressor.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
-import 'package:ffmpeg_cli/ffmpeg_cli.dart';
+import 'package:fc_native_video_thumbnail/fc_native_video_thumbnail.dart';
 import 'package:flutter/material.dart';
 import 'package:image_compression/image_compression.dart' as imageCompression;
 import 'package:image_compression/image_compression_io.dart';
@@ -27,63 +28,66 @@ Future<File> getImageThumbnail(BooruImage image) async {
 
     debugPrint("Compressing $filename");
 
-    final compressedImage = await compressToThumbnail(image.getImage());
+    final thumbnail = await createThumbnail(
+		input: image.getImage(),
+		outputPath: thumbnailFile.absolute.path
+	);
     debugPrint("Obtained ${p.basename(thumbnailFile.path)}");
 
-    await thumbnailFile.writeAsBytes(compressedImage.rawBytes);
-
-    return thumbnailFile;
+    return thumbnail;
 }
 
-Future<ImageFile> compressToThumbnail(File file,) async {
-    ImageFile input;
+Future<File> createThumbnail({required File input, required String outputPath}) async {
+    File outputFile;
 
-    final mime = lookupMimeType(file.path);
-    /*if(mime!.startsWith("video/") || mime == "image/gif") {
-        input = ImageFile(
-            filePath: file.path,
-            rawBytes: await getVideoFirstFrame(file.path)
-        );
-    } else*/ if(mime!.startsWith("image/")) {
-        input = ImageFile(
-            filePath: file.path,
-            rawBytes: await file.readAsBytes()
-        );
+    final mime = lookupMimeType(input.path);
+    if(mime!.startsWith("video/") || mime == "image/gif") {
+        final hadGenerated = await generateVideoThumbnail(
+			inputPath: input.path,
+			outputPath: outputPath
+		).catchError((error) {
+			debugPrint("meow");
+			throw error;
+		});
+		if(!hadGenerated) throw "Could not generate thumbnail from video";
+		outputFile = File(outputPath);
+    } else if(mime.startsWith("image/")) {
+    	final compressedImage = await compressImage(ImageFile(
+            filePath: input.path,
+            rawBytes: await input.readAsBytes()
+        ));
+		outputFile = await File(outputPath).writeAsBytes(compressedImage.rawBytes);
     } else {
         throw "Unknown file type";
     }
 
-    final compressedImage = await compressImage(input);
-    return compressedImage;
+    return outputFile;
 }
 
-// update to not depend on media_kit
-// Future<Uint8List> getVideoFirstFrame(String path) async {
-//     final player = Player();
-//     final controller = VideoController(player); // has to be created according to https://github.com/media-kit/media-kit/issues/419#issuecomment-1703855470
-    
-//     await player.open(Media(path), play: false);
-//     await controller.waitUntilFirstFrameRendered;
-//     await Future.delayed(const Duration(milliseconds: 500)); // idk why but this works
-    
-//     await player.seek(Duration.zero); 
-    
-//     final bytes = await player.screenshot();
-    
-//     player.dispose();
-    
-//     return bytes!;
-// }
+//update to not depend on media_kit
+Future<bool> generateVideoThumbnail({required String inputPath, required String outputPath}) async {
+    debugPrint("getting thumbnail");
+    final plugin = FcNativeVideoThumbnail();
+    final thumbnailGenerated = await plugin.getVideoThumbnail(
+        srcFile: inputPath,
+        destFile: outputPath,
+        width: 10000,  // i will be impressed if i find a 10.000x10.000 video size
+        height: 10000,
+		format: 'jpeg',
+        quality: 30
+	);
+    return thumbnailGenerated;
+}
 
 
 Future<File> compress(File file) async {
     final tempDir = await getTemporaryDirectory();
     
     final mime = lookupMimeType(file.path)!;
-    if(mime.startsWith("video/") || mime == "image/gif") {
+    /*if(mime.startsWith("video/") || mime == "image/gif") {
         final compressedVideo = await compressVideo(file);
         return compressedVideo;
-    } else if(mime.startsWith("image/")) {
+    } else*/ if(mime.startsWith("image/")) {
         final compressedImage = await compressImage(ImageFile(
             filePath: file.path,
             rawBytes: await file.readAsBytes()
@@ -105,54 +109,54 @@ Future<ImageFile> compressImage(ImageFile file, {int quality = 30}) {
     ));
 }
 
-Future<File> compressVideo(File file, {int crf = 32}) async {
-    // FFmpeg ffmpeg = createFFmpeg(CreateFFmpegParam(log: true, corePath: 'https://unpkg.com/@ffmpeg/core@0.11.0/dist/ffmpeg-core.js'));
+// Future<File> compressVideo(File file, {int crf = 32}) async {
+//     // FFmpeg ffmpeg = createFFmpeg(CreateFFmpegParam(log: true, corePath: 'https://unpkg.com/@ffmpeg/core@0.11.0/dist/ffmpeg-core.js'));
 
-    // await ffmpeg.load();
+//     // await ffmpeg.load();
 
-    // final extension = p.extension(file.path);
+//     // final extension = p.extension(file.path);
 
-    // final inputFile = "input$extension";
-    // final outputFile = "output$extension";
+//     // final inputFile = "input$extension";
+//     // final outputFile = "output$extension";
 
-    // ffmpeg.writeFile(inputFile, await file.readAsBytes());
+//     // ffmpeg.writeFile(inputFile, await file.readAsBytes());
 
-    // await ffmpeg.run(["-i", inputFile, "-crf", crf.toString(), "-o", outputFile]);
+//     // await ffmpeg.run(["-i", inputFile, "-crf", crf.toString(), "-o", outputFile]);
 
-    // final data = ffmpeg.readFile(outputFile);
+//     // final data = ffmpeg.readFile(outputFile);
 
-    // return data;
+//     // return data;
 
-    final tempDir = await getTemporaryDirectory();
-    final outputPath = p.join(tempDir.path, p.basename(file.path));
+//     final tempDir = await getTemporaryDirectory();
+//     final outputPath = p.join(tempDir.path, p.basename(file.path));
 
-    final command = FfmpegCommand.simple(
-        inputs: [
-            FfmpegInput.asset(file.path)
-        ],
-        args: [
-            CliArg(name: "crf", value: "$crf"),
-            const CliArg(name: "y")
-        ],
-        outputFilepath: outputPath
-    );
+//     final command = FfmpegCommand.simple(
+//         inputs: [
+//             FfmpegInput.asset(file.path)
+//         ],
+//         args: [
+//             CliArg(name: "crf", value: "$crf"),
+//             const CliArg(name: "y")
+//         ],
+//         outputFilepath: outputPath
+//     );
 
-    debugPrint("Running ${command.expectedCliInput()}");
+//     debugPrint("Running ${command.expectedCliInput()}");
 
-    final process = await Ffmpeg().run(command);
+//     final process = await Ffmpeg().run(command);
 
-    // Pipe the process output to the Dart console.
-    process.stderr.transform(utf8.decoder).listen((data) {
-        debugPrint(data);
-    });
+//     // Pipe the process output to the Dart console.
+//     process.stderr.transform(utf8.decoder).listen((data) {
+//         debugPrint(data);
+//     });
 
-    // // Allow the user to respond to FFMPEG queries, such as file overwrite
-    // // confirmations.
-    // stdin.pipe(process.stdin);
+//     // // Allow the user to respond to FFMPEG queries, such as file overwrite
+//     // // confirmations.
+//     // stdin.pipe(process.stdin);
 
-    debugPrint("processHell");
+//     debugPrint("processHell");
 
-    await process.exitCode;
+//     await process.exitCode;
 
-    return File(outputPath);
-}
+//     return File(outputPath);
+// }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import device_info_plus
 import dynamic_color
+import fc_native_video_thumbnail
 import fvp
 import irondash_engine_context
 import local_auth_darwin
@@ -26,6 +27,7 @@ import window_manager
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
+  FcNativeVideoThumbnailPlugin.register(with: registry.registrar(forPlugin: "FcNativeVideoThumbnailPlugin"))
   FvpPlugin.register(with: registry.registrar(forPlugin: "FvpPlugin"))
   IrondashEngineContextPlugin.register(with: registry.registrar(forPlugin: "IrondashEngineContextPlugin"))
   FLALocalAuthPlugin.register(with: registry.registrar(forPlugin: "FLALocalAuthPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -190,6 +190,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  fc_native_video_thumbnail:
+    dependency: "direct main"
+    description:
+      name: fc_native_video_thumbnail
+      sha256: "61836a6fd34bb0cbda48d7ba7cd7a23242468886d4c68017ae59b9791fb42d2a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.16.1"
   ffi:
     dependency: transitive
     description:
@@ -198,14 +206,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
-  ffmpeg_cli:
-    dependency: "direct main"
-    description:
-      name: ffmpeg_cli
-      sha256: a7704193b6885d3ff4b00c6ec4bcd08d607a243e56da8a43faab7ce7a313b2ed
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.0"
   file:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,7 +66,6 @@ dependencies:
   image_compression: ^1.0.5
   vector_math: ^2.1.4
   photo_view: ^0.15.0
-  ffmpeg_cli: ^0.3.0
   super_drag_and_drop: ^0.9.0-dev.4
   sliver_tools: ^0.2.12
   local_auth: ^2.2.0
@@ -81,6 +80,7 @@ dependencies:
   fvp: ^0.28.0
   video_player: ^2.9.2
   chewie: ^1.8.5
+  fc_native_video_thumbnail: ^0.16.1
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
+#include <fc_native_video_thumbnail/fc_native_video_thumbnail_plugin_c_api.h>
 #include <fvp/fvp_plugin_c_api.h>
 #include <irondash_engine_context/irondash_engine_context_plugin_c_api.h>
 #include <local_auth_windows/local_auth_plugin.h>
@@ -20,6 +21,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   DynamicColorPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
+  FcNativeVideoThumbnailPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FcNativeVideoThumbnailPluginCApi"));
   FvpPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FvpPluginCApi"));
   IrondashEngineContextPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
+  fc_native_video_thumbnail
   fvp
   irondash_engine_context
   local_auth_windows


### PR DESCRIPTION
This pull request involves significant changes to the `lib/utils/compressor.dart` file to replace the `ffmpeg_cli` package with the `fc_native_video_thumbnail` package for generating video thumbnail. The reason behind is that ffmpeg has to be provided by the system, and not by the application, meaning that if the system does not have ffmpeg, then it cannot generate thumbnails. `fc_native_video_thumbnail` does use native implementations, but it does not support Linux  
Sadly there's no other cross platform option when it comes to extracting a thumbnail other than ffmpeg, and screenshotting a video player is not possible (SachinGanesh/screenshot#62)

### Package changes:
* Removed `ffmpeg_cli` dependency and added `fc_native_video_thumbnail`