### PR TITLE
Add a button to import images directly on the bulk adding menu

### DIFF
--- a/lib/views/image_manager/shell.dart
+++ b/lib/views/image_manager/shell.dart
@@ -7,7 +7,9 @@ import 'package:go_router/go_router.dart';
 import 'package:localbooru/api/index.dart';
 import 'package:localbooru/api/preset/index.dart';
 import 'package:localbooru/components/app_bar_linear_progress.dart';
+import 'package:localbooru/components/dialogs/download_dialog.dart';
 import 'package:localbooru/components/dialogs/image_selector_dialog.dart';
+import 'package:localbooru/components/dialogs/textfield_dialogs.dart';
 import 'package:localbooru/utils/platform_tools.dart';
 import 'package:localbooru/views/image_manager/form.dart';
 import 'package:localbooru/views/image_manager/general_collection_manager.dart';
@@ -219,6 +221,35 @@ class _ImageManagerShellState extends State<ImageManagerShell> {
                                                 errorOnPages.add(false);
                                                 return image;
                                             })));
+                                            setState(() => imagePage = preset.pages!.length - 1);
+                                            _scaffoldKey.currentState!.closeEndDrawer();
+                                        }
+                                    ),
+									ListTile(
+                                        title: const Text("Import from external website"),
+                                        leading: const Icon(Icons.download),
+                                        onTap: () async {
+                                            final url = await showDialog<String>(
+                                                context: context,
+                                                builder: (context) {
+                                                    return const InsertURLDialog();
+                                                },
+                                            );
+                                            if(url == null) return;
+                                            final downloadedPreset = await importImageFromURL(url);
+                                            // final images = await openSelectionDialog(
+                                            //     context: context,
+                                            //     excludeImages: preset.pages!.where((imagePreset) => imagePreset.replaceID != null,).map((imagePreset) => imagePreset.replaceID!).toList()
+                                            // );
+                                            if(downloadedPreset is PresetImage) {
+                                                downloadedPreset.key = UniqueKey();
+                                                preset.pages!.add(downloadedPreset);
+                                                errorOnPages.add(false);
+                                            } else if (downloadedPreset is VirtualPresetCollection) {
+                                                final presets = downloadedPreset.pages;
+                                                if(presets == null) return;
+                                                preset.pages!.addAll(presets);
+                                            }
                                             setState(() => imagePage = preset.pages!.length - 1);
                                             _scaffoldKey.currentState!.closeEndDrawer();
                                         }


### PR DESCRIPTION
This feature adds a menu option below the "Edit existing image" option that can import an image and add directly to the bulk add stack

One of the benefits behind this feature is for importing alternative versions of an image without having to manually add each image, select the images to bulk-edit them, and mark the option to correlate all images
![image](https://github.com/user-attachments/assets/5a180b32-f7e3-45d1-9389-56df1dfb38f7)


https://github.com/user-attachments/assets/33fa7ce7-dee3-4346-b76f-4e7b4c6f8364

### Possible additions
- [ ] - prompt to add the image when sharing to the app and being on the image_manager screen
- [ ] - option to add multiple images on the import prompt
