### PR TITLE
(Stage 1/2) Rename "illegal" rating to "borderline"

### DIFF
--- a/lib/api/tags.dart
+++ b/lib/api/tags.dart
@@ -96,11 +96,12 @@ Future<bool> doTagMatch({required Map file, required TagText tag}) async {
         final Metatag metatag = Metatag(tag);
         switch (metatag.selector) {
             case "rating":
-                return (metatag.value == "none" && file["rating"] == null)
-                    || ((metatag.value == "safe" || metatag.value == "s") && file["rating"] == "safe")
-                    || ((metatag.value == "questionable" || metatag.value == "q") && file["rating"] == "questionable")
-                    || ((metatag.value == "explicit" || metatag.value == "e") && file["rating"] == "explicit")
-                    || ((metatag.value == "illegal" || metatag.value == "i") && file["rating"] == "illegal");
+                return (metatag.value == "none" && file["rating"] == null) // none
+                    || ((metatag.value == "safe" || metatag.value == "s") && file["rating"] == "safe") // safe
+                    || ((metatag.value == "questionable" || metatag.value == "q") && file["rating"] == "questionable") // questionable
+                    || ((metatag.value == "explicit" || metatag.value == "e") && file["rating"] == "explicit") // explicit
+                    || ((metatag.value == "illegal" || metatag.value == "i") && file["rating"] == "illegal") // borderline (old name)
+                    || ((metatag.value == "borderline" || metatag.value == "b") && file["rating"] == "illegal"); // borderline (new name)
             case "id":
                 return rangeMatch(double.parse(file["id"]), metatag.value) || metatag.value == file["id"];
             case "type":

--- a/lib/components/dialogs/radio_dialogs.dart
+++ b/lib/components/dialogs/radio_dialogs.dart
@@ -25,7 +25,7 @@ class RatingChooserDialog extends StatelessWidget {
                             spacing: 8,
                             children: [
                                 Icon(getRatingIcon(rating)),
-                                Text(rating == null ? "None" : rating.name.replaceFirstMapped(rating.name[0], (match) => rating.name[0].toUpperCase())),
+                                Text(getRatingText(rating)),
                             ],
                         ),
                         onChanged: (value) => Navigator.of(context).pop(value ?? "None"),

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -131,3 +131,13 @@ IconData getRatingIcon(Rating? rating) {
         _ => Icons.clear
     };
 }
+
+String getRatingText(Rating? rating) {
+    return switch(rating) {
+        Rating.safe => "Safe",
+        Rating.questionable => "Questionable",
+        Rating.explicit => "Explicit",
+        Rating.illegal => "Borderline",
+        _ => "None"
+    };
+}

--- a/lib/views/image_manager/form.dart
+++ b/lib/views/image_manager/form.dart
@@ -251,13 +251,7 @@ class _ImageManagerFormState extends State<ImageManagerForm> {
                         const SmallHeader("Rating", padding: EdgeInsets.only(top: 16.0)),
                         ListTile(
                             leading: Icon(getRatingIcon(rating)),
-                            title: Text(switch(rating) {
-                                Rating.safe => "Safe",
-                                Rating.questionable => "Questionable",
-                                Rating.explicit => "Explicit",
-                                Rating.illegal => "Illegal",
-                                _ => "None"
-                            }),
+                            title: Text(getRatingText(rating)),
                             onTap: () async {
                                 final choosenRating = await showDialog(
                                     context: context,

--- a/lib/views/navigation/home.dart
+++ b/lib/views/navigation/home.dart
@@ -220,7 +220,7 @@ final List<String> tagsToAddToSearch = [
     "rating:safe",
     "rating:questionable",
     "rating:explicit",
-    "rating:illegal",
+    "rating:borderline",
     "id:",
     "file:",
     "type:",

--- a/lib/views/navigation/image_view.dart
+++ b/lib/views/navigation/image_view.dart
@@ -340,13 +340,7 @@ class _ImageViewProprietiesState extends State<ImageViewProprieties> {
                             child: ListTile(
                                 title: const SmallHeader("Rating", padding: EdgeInsets.zero,),
                                 leading: Icon(getRatingIcon(widget.image.rating!), color: Theme.of(context).colorScheme.primary),
-                                subtitle: Text(switch(widget.image.rating) {
-                                    Rating.safe => "Safe",
-                                    Rating.questionable => "Questionable",
-                                    Rating.explicit => "Explicit",
-                                    Rating.illegal => "Illegal",
-                                    _ => widget.image.rating!.name
-                                }),
+                                subtitle: Text(getRatingText(widget.image.rating)),
                             )
                         )
                     ],


### PR DESCRIPTION
This pull request aims to rename the "illegal" rating to "borderline" to avoid possible backlash with the name

The "illegal" rating gives an idea that we promote the usage of "malicious images" on our program, where in fact the tag was meant to filter content that may not be deemed "acceptable" by mainstream beliefs and that brings shaming issues

The reason that this is a two stage PR is due to release constrains. Plans are to remove any mentions of the "illegal" rating both internally and externally, but due to the mentioned issue, besides possible incompatibles, it is still referred as "illegal" in-code, but it is displayed as "borderline" to the final user